### PR TITLE
Fixing substring command

### DIFF
--- a/utf8.lua
+++ b/utf8.lua
@@ -129,6 +129,7 @@ function utf8.sub(s, start_ci, end_ci)
 		end
 		if ci == end_ci + 1 then
 			end_i = i - 1
+			break
 		end
 	end
 	if not start_i then

--- a/utf8.lua
+++ b/utf8.lua
@@ -120,14 +120,15 @@ function utf8.sub(s, start_ci, end_ci)
 	assert(start_ci >= 1)
 	assert(not end_ci or end_ci >= 0)
 	local ci = 0
-	local start_i, end_i
+	local start_i = 1
+	local end_i = s:len()
 	for i in utf8.byte_indices(s) do
 		ci = ci + 1
 		if ci == start_ci then
 			start_i = i
 		end
-		if ci == end_ci then
-			end_i = i
+		if ci == end_ci + 1 then
+			end_i = i - 1
 		end
 	end
 	if not start_i then


### PR DESCRIPTION
A more substantive commit this time. :)

Consider the string `abçd`, corresponding to the UTF-8 bytes `ab\xc3\xa7d`.  Suppose we want to get the substring from character 2 through character 3, `bç`, corresponding to bytes 2 through 4.

The current implementation of *sub* is as follows:

```lua
function utf8.sub(s, start_ci, end_ci)
	-- ...
	for i in utf8.byte_indices(s) do
		ci = ci + 1
		if ci == start_ci then
			start_i = i
		end
		if ci == end_ci then
			end_i = i
		end
	end
	-- ...
	return s:sub(start_i, end_i)
end
```

The "byte_indices" iterator will return the following sequence: 1, 2, 3, 5.  So, the function will incorrectly return bytes 2 through 3.

Here's my modified version:

```lua
function lutf8_sub(s, start_ci, end_ci)
	-- ...
	for i in utf8.byte_indices(s) do
		ci = ci + 1
		if ci == start_ci then
			start_i = i
		end
		if ci == end_ci+1 then
			end_i = i-1
		end
	end
	-- ...
	return s:sub(start_i, end_i)
end
```

In words, it returns the byte index equal to one before the byte index of the next UTF-8 character.

Since the UTF-8 character might be the last character in the string, my commit also makes `end_i` default to the end of the string.